### PR TITLE
Removed (almost) all Try examples in documentation/comment blocks

### DIFF
--- a/arrow-docs/docs/iso/README.md
+++ b/arrow-docs/docs/iso/README.md
@@ -60,16 +60,16 @@ We can do the same with a Functor mapping.
 
 ```kotlin:ank
 import arrow.core.*
-import arrow.core.extensions.`try`.functor.*
+import arrow.core.extensions.either.functor.*
 
-pointIsoTuple.modifyF(Try.functor(), point) {
-    Try { (tuple.a / 2) toT (tuple.b / 2) }
+pointIsoTuple.modifyF(Either.functor(), point) {
+    Either.right((tuple.a / 2) toT (tuple.b / 2))
 }
 ```
 
 ```kotlin:ank
-val liftF: (Point2D) -> TryOf<Point2D> = pointIsoTuple.liftF(Try.functor()) {
-    Try { (tuple.a / 2) toT (tuple.b / 0) }
+val liftF: (Point2D) -> EitherOf<Throwable, Point2D> = pointIsoTuple.liftF(Either.functor()) {
+    try { Either.right((tuple.a / 2) toT (tuple.b / 0)) } catch(e:Throwable) { Either.left(e) }
 }
 
 liftF(point)

--- a/arrow-docs/docs/iso/README.md
+++ b/arrow-docs/docs/iso/README.md
@@ -63,7 +63,7 @@ import arrow.core.*
 import arrow.core.extensions.either.functor.*
 
 pointIsoTuple.modifyF(Either.functor(), point) {
-    Either.right((tuple.a / 2) toT (tuple.b / 2))
+    try { Either.right((tuple.a / 2) toT (tuple.b / 2)) } catch(e: Exception) { Either.left(e) }
 }
 ```
 

--- a/arrow-docs/docs/optional/README.md
+++ b/arrow-docs/docs/optional/README.md
@@ -48,26 +48,30 @@ lifted(emptyList<Int>().k())
 Or modify or lift functions using `Applicative`.
 
 ```kotlin:ank
-import arrow.core.extensions.`try`.applicative.*
+import arrow.fx.IO
+import arrow.core.extensions.option.applicative.*
 
-ListK.head<Int>().modifyF(Try.applicative(), listOf(1, 3, 6).k()) { head ->
-    Try { head / 2 }
+ListK.head<Int>().modifyF(Option.applicative(), listOf(1, 3, 6).k()) { head ->
+    Option.just(head/2)
 }
 ```
 ```kotlin:ank
-val liftedF = ListK.head<Int>().liftF(Try.applicative()) { head ->
-    Try { head / 0 }
+import arrow.fx.extensions.io.applicative.*
+
+val liftedFO = ListK.head<Int>().liftF(IO.applicative()) { head ->
+    IO.effect { head / 0 }
 }
-liftedF(listOf(1, 3, 6).k())
 ```
 
 An `Optional` instance can be manually constructed from any default or custom `Iso`, `Lens`, or `Prism` instance by calling their `asOptional()` or by creating a custom `Optional` instance as shown above.
 
 ### Composition
 
-We can compose `Optional`s to build telescopes with an optional focus. Imagine we try to retrieve a `User`'s email from a backend. The result of our call is `Try<User>`. So, we first want to look into `Try`, which **optionally** could be a `Success`. And then we want to look into `User`, which optionally filled in his email.
+We can compose `Optional`s to build telescopes with an optional focus. Imagine we try to retrieve a `User`'s email from a backend. The result of our call is `Option<User>`. So, we first want to look into `Option`, which **optionally** could be a `Some`. And then we want to look into `User`, which optionally filled in his email.
 
 ```kotlin:ank
+import arrow.optics.some
+
 data class Participant(val name: String, val email: String?)
 
 val participantEmail: Optional<Participant, String> = Optional(
@@ -75,12 +79,15 @@ val participantEmail: Optional<Participant, String> = Optional(
         set = { participant, email -> participant.copy(email = email) }
 )
 
-val triedEmail: Optional<Try<Participant>, String> = Try.success<Participant>() compose participantEmail
+val optEmail: Optional<Option<Participant>, String> = Option.some<Participant>() compose participantEmail
 
-triedEmail.getOption(Try.Success(Participant("test", "email")))
+optEmail.getOption(Some(Participant("test", "email")))
 ```
 ```kotlin:ank
-triedEmail.getOption(Try.Failure(IllegalStateException("Something wrong with network")))
+optEmail.getOption(None)
+```
+```kotlin:ank
+optEmail.getOption(Some(Participant("test", null)))
 ```
 
 `Optional` can be composed with all optics, resulting in the following optics:
@@ -108,20 +115,19 @@ val optionalAddress: Optional<Person, Address> = Person.address
 
 A `POptional` is very similar to [PLens]({{'/optics/lens#Plens' | relative_url }}) and [PPrism]({{'/optics/prism#PPrism' | relative_url }}). So let's see if we can combine both examples shown in their documentation.
 
-Given a `PPrism` with a focus into `Success` of `Try<Tuple2<Int, String>>` that can polymorphically change its content to `Tuple2<String, String>` and a `PLens` with a focus into the `Tuple2<Int, String>` that can morph the first parameter from `Int` to `String`, we can compose them together building an `Optional` that can look into `Try` and morph the first type of the `Tuple2` within.
+Given a `PPrism` with a focus into `Some` of `Option<Tuple2<Int, String>>` that can polymorphically change its content to `Tuple2<String, String>` and a `PLens` with a focus into the `Tuple2<Int, String>` that can morph the first parameter from `Int` to `String`, we can compose them together building an `Optional` that can look into `Option` and morph the first type of the `Tuple2` within.
 
 ```kotlin:ank
-val pprism = Try.pSuccess<Tuple2<Int, String>, Tuple2<String, String>>()
+val pprism = Option.PSome<Tuple2<Int, String>, Tuple2<String, String>>()
 val plens = Tuple2.pFirst<Int, String, String>()
 
-val successTuple2: POptional<Try<Tuple2<Int, String>>, Try<Tuple2<String, String>>, Int, String> =
-        pprism compose plens
+val someTuple2: POptional<Option<Tuple2<Int, String>>, Option<Tuple2<String, String>>, Int, String> =
+    pprism compose plens
 
-val lifted: (Try<Tuple2<Int, String>>) -> Try<Tuple2<String, String>> = successTuple2.lift { _ -> "Hello, " }
-lifted(Try.Success(5 toT "World!"))
+val lifted: (Option<Tuple2<Int, String>>) -> Option<Tuple2<String, String>> = someTuple2.lift { _ -> "Hello, " }
 ```
 ```kotlin:ank
-lifted(Try.Failure(IllegalStateException("something went wrong")))
+lifted(None)
 ```
 
 ### Laws

--- a/arrow-docs/docs/optional/README.md
+++ b/arrow-docs/docs/optional/README.md
@@ -57,6 +57,7 @@ ListK.head<Int>().modifyF(Option.applicative(), listOf(1, 3, 6).k()) { head ->
 ```
 ```kotlin:ank
 import arrow.fx.extensions.io.applicative.*
+import arrow.fx.fix
 
 val liftedFO = ListK.head<Int>().liftF(IO.applicative()) { head ->
     IO.effect { head / 0 }

--- a/arrow-docs/docs/optional/README.md
+++ b/arrow-docs/docs/optional/README.md
@@ -61,7 +61,7 @@ import arrow.fx.extensions.io.applicative.*
 val liftedFO = ListK.head<Int>().liftF(IO.applicative()) { head ->
     IO.effect { head / 0 }
 }
-liftedFO(listOf(1, 3, 6).k()).attempt().unsafeRunSync()
+liftedFO(listOf(1, 3, 6).k()).fix().attempt().unsafeRunSync()
 ```
 
 An `Optional` instance can be manually constructed from any default or custom `Iso`, `Lens`, or `Prism` instance by calling their `asOptional()` or by creating a custom `Optional` instance as shown above.

--- a/arrow-docs/docs/optional/README.md
+++ b/arrow-docs/docs/optional/README.md
@@ -61,6 +61,7 @@ import arrow.fx.extensions.io.applicative.*
 val liftedFO = ListK.head<Int>().liftF(IO.applicative()) { head ->
     IO.effect { head / 0 }
 }
+liftedFO(listOf(1, 3, 6).k()).attempt().unsafeRunSync()
 ```
 
 An `Optional` instance can be manually constructed from any default or custom `Iso`, `Lens`, or `Prism` instance by calling their `asOptional()` or by creating a custom `Optional` instance as shown above.

--- a/arrow-docs/docs/prism/README.md
+++ b/arrow-docs/docs/prism/README.md
@@ -134,19 +134,19 @@ val rectangleShape: Prism<Shape, Shape.Rectangle> = Shape.rectangle
 ```
 
 ### Polymorphic prisms <a id="PPrism"></a>
-When dealing with polymorphic sum types like `Try<A>`, we can also have polymorphic prisms that allow us to polymorphically change the type of the focus of our `PPrism`. The following method is also available as `pTrySuccess<A, B>()` in the `arrow.optics` package:
+When dealing with polymorphic sum types like `Option<A>`, we can also have polymorphic prisms that allow us to polymorphically change the type of the focus of our `PPrism`. The following method is also available as `PSome<A, B>()` in the `arrow.optics` package:
 
 ```kotlin
-fun <A, B> trySuccess(): PPrism<Try<A>, Try<B>, A, B> = PPrism(
-        getOrModify = { aTry -> aTry.fold({ Try.Failure(it).left() }, { it.right() }) },
-        reverseGet = { b -> Try.Success(b) }
+fun <A, B> optionSome(): PPrism<Option<A>, Option<B>, A, B> = PPrism(
+    getOrModify = { option -> option.fold({ Either.Left(None) }, { Either.Right(it) }) },
+    reverseGet = { b -> Some(b) }
 )
 
-val liftSuccess: (Try<Int>) -> Try<String> = pTrySuccess<Int, String>().lift(Int::toString)
-liftSuccess(Try.Success(5))
+val liftSome: (Option<Int>) -> Option<String> = PSome<Int, String>().lift(Int::toString)
+liftSome(Some(5))
 ```
 ```kotlin
-liftSuccess(Try.Failure(ArithmeticException("/ by zero")))
+liftSuccess(None)
 ```
 
 ### Laws

--- a/arrow-docs/docs/traversal/README.md
+++ b/arrow-docs/docs/traversal/README.md
@@ -23,17 +23,17 @@ import arrow.optics.*
 import arrow.core.*
 import arrow.mtl.*
 import arrow.core.extensions.listk.traverse.*
-import arrow.core.extensions.`try`.applicative.*
+import arrow.core.extensions.option.applicative.*
 
 val listTraversal: Traversal<ListKOf<Int>, Int> = Traversal.fromTraversable(ListK.traverse())
 
-listTraversal.modifyF(Try.applicative(), listOf(1, 2, 3).k()) {
-    Try { it / 2 }
+listTraversal.modifyF(Option.applicative(), listOf(1, 2, 3).k()) {
+    Option.just(it / 2)
 }
 ```
 ```kotlin:ank
-listTraversal.modifyF(Try.applicative(), listOf(0, 2, 3).k()) {
-    Try { throw TryException.UnsupportedOperationException("Any arbitrary exception") }
+listTraversal.modifyF(Option.applicative(), listOf(0, 2, 3).k()) {
+    try { Option.just(it / 0) } catch(e: Throwable) { None } 
 }
 ```
 

--- a/arrow-optics/src/main/kotlin/arrow/optics/Prism.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Prism.kt
@@ -32,7 +32,7 @@ typealias PrismKindedJ<S, A> = PPrismKindedJ<S, S, A, A>
  * Mostly used for finding a focus that is only present under certain conditions i.e. list head Prism<List<Int>, Int>
  *
  * A (polymorphic) [PPrism] is useful when setting or modifying a value for a polymorphic sum type
- * i.e. PPrism<Try<Sting>, Try<Int>, String, Int>
+ * i.e. PPrism<Option<String>, Option<Int>, String, Int>
  *
  * A [PPrism] gathers the two concepts of pattern matching and constructor and thus can be seen as a pair of functions:
  * - `getOrModify: A -> Either<A, B>` meaning it returns the focus of a [PPrism] OR the original value

--- a/arrow-optics/src/test/kotlin/arrow/optics/OptionalTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/OptionalTest.kt
@@ -1,22 +1,27 @@
 package arrow.optics
 
+import arrow.Kind
 import arrow.core.Left
+import arrow.core.ListK
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Right
 import arrow.core.Try
-import arrow.core.getOrElse
-import arrow.core.identity
-import arrow.core.toOption
-import arrow.core.toT
 import arrow.core.extensions.`try`.applicative.applicative
-import arrow.core.extensions.monoid
-import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.list.foldable.nonEmpty
 import arrow.core.extensions.listk.eq.eq
-import arrow.core.ListK
-import arrow.mtl.State
+import arrow.core.extensions.monoid
+import arrow.core.extensions.option.eq.eq
+import arrow.core.getOrElse
+import arrow.core.identity
 import arrow.core.k
+import arrow.core.toOption
+import arrow.core.toT
+import arrow.fx.ForIO
+import arrow.fx.IO
+import arrow.fx.extensions.io.applicative.applicative
+import arrow.fx.fix
+import arrow.mtl.State
 import arrow.mtl.map
 import arrow.mtl.run
 import arrow.optics.mtl.assign
@@ -105,6 +110,16 @@ class OptionalTest : UnitSpec() {
       funcGen = Gen.functionAToB(Gen.int()),
       EQA = Eq.any()
     ))
+
+//    "Test" {
+//      val liftedFO: (source: List<Int>) -> Kind<ForIO, List<Int>> = ListK.head<Int>().liftF(IO.applicative()) { head ->
+//        IO.effect { head / 0 }
+//      }
+//
+//      val liftedFO1: Kind<ForIO, List<Int>> = liftedFO(listOf(1, 3, 6).k())
+//      val fix: IO<List<Int>> = liftedFO1.fix()
+//      fix.attempt().unsafeRunSync()
+//    }
 
     "asSetter should set absent optional" {
       forAll(genIncompleteUser, genToken) { user, token ->

--- a/arrow-optics/src/test/kotlin/arrow/optics/OptionalTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/OptionalTest.kt
@@ -1,6 +1,5 @@
 package arrow.optics
 
-import arrow.Kind
 import arrow.core.Left
 import arrow.core.ListK
 import arrow.core.None
@@ -17,10 +16,7 @@ import arrow.core.identity
 import arrow.core.k
 import arrow.core.toOption
 import arrow.core.toT
-import arrow.fx.ForIO
-import arrow.fx.IO
 import arrow.fx.extensions.io.applicative.applicative
-import arrow.fx.fix
 import arrow.mtl.State
 import arrow.mtl.map
 import arrow.mtl.run
@@ -110,16 +106,6 @@ class OptionalTest : UnitSpec() {
       funcGen = Gen.functionAToB(Gen.int()),
       EQA = Eq.any()
     ))
-
-//    "Test" {
-//      val liftedFO: (source: List<Int>) -> Kind<ForIO, List<Int>> = ListK.head<Int>().liftF(IO.applicative()) { head ->
-//        IO.effect { head / 0 }
-//      }
-//
-//      val liftedFO1: Kind<ForIO, List<Int>> = liftedFO(listOf(1, 3, 6).k())
-//      val fix: IO<List<Int>> = liftedFO1.fix()
-//      fix.attempt().unsafeRunSync()
-//    }
 
     "asSetter should set absent optional" {
       forAll(genIncompleteUser, genToken) { user, token ->

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/EitherTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/EitherTest.kt
@@ -1,9 +1,10 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.Either
 import arrow.core.Invalid
 import arrow.core.Valid
 import arrow.core.Validated
+import arrow.optics.toValidated
 import arrow.test.UnitSpec
 import arrow.test.generators.either
 import arrow.test.generators.functionAToB

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/IdInstancesTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/IdInstancesTest.kt
@@ -1,7 +1,8 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.Id
 import arrow.core.extensions.monoid
+import arrow.optics.toValue
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.laws.IsoLaws

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/ListTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/ListTest.kt
@@ -1,4 +1,4 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.ListExtensions
 import arrow.core.Option
@@ -8,6 +8,10 @@ import arrow.core.ListK
 import arrow.core.NonEmptyList
 import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.nonemptylist.semigroup.semigroup
+import arrow.optics.head
+import arrow.optics.tail
+import arrow.optics.toListK
+import arrow.optics.toOptionNel
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.generators.nonEmptyList

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/MapTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/MapTest.kt
@@ -1,8 +1,9 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.MapK
 import arrow.core.SetK
 import arrow.core.extensions.setk.monoid.monoid
+import arrow.optics.toSetK
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.generators.genSetK

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/NonEmptyListTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/NonEmptyListTest.kt
@@ -1,7 +1,9 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.NonEmptyList
 import arrow.core.extensions.monoid
+import arrow.optics.head
+import arrow.optics.tail
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.generators.nonEmptyList

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/OptionTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/OptionTest.kt
@@ -1,4 +1,4 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.Either
 import arrow.core.Option
@@ -7,6 +7,10 @@ import arrow.core.extensions.monoid
 import arrow.core.extensions.either.applicative.applicative
 import arrow.core.extensions.option.monoid.monoid
 import arrow.core.fix
+import arrow.optics.none
+import arrow.optics.some
+import arrow.optics.toEither
+import arrow.optics.toNullable
 import arrow.test.UnitSpec
 import arrow.test.generators.either
 import arrow.test.generators.functionAToB

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/SetTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/SetTest.kt
@@ -1,8 +1,9 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.SetExtensions
 import arrow.core.SetK
 import arrow.core.extensions.setk.monoid.monoid
+import arrow.optics.toSetK
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.generators.genSetK

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/StringTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/StringTest.kt
@@ -1,6 +1,7 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.extensions.monoid
+import arrow.optics.toList
 import arrow.test.UnitSpec
 import arrow.test.generators.char
 import arrow.test.laws.IsoLaws

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/TryTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/TryTest.kt
@@ -1,4 +1,4 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.Either
 import arrow.core.Right
@@ -8,6 +8,10 @@ import arrow.core.fix
 import arrow.core.Invalid
 import arrow.core.Valid
 import arrow.core.Validated
+import arrow.optics.failure
+import arrow.optics.success
+import arrow.optics.toEither
+import arrow.optics.toValidated
 import arrow.test.UnitSpec
 import arrow.test.generators.`try`
 import arrow.test.generators.either

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/TupleTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/TupleTest.kt
@@ -1,4 +1,4 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.ListK
 import arrow.core.Option
@@ -15,6 +15,10 @@ import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.monoid
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.tuple2.monoid.monoid
+import arrow.optics.first
+import arrow.optics.second
+import arrow.optics.third
+import arrow.optics.traversal
 import arrow.test.UnitSpec
 import arrow.test.generators.functionAToB
 import arrow.test.generators.tuple10

--- a/arrow-optics/src/test/kotlin/arrow/optics/std/ValidatedTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/std/ValidatedTest.kt
@@ -1,4 +1,4 @@
-package arrow.optics
+package arrow.optics.std
 
 import arrow.core.Either
 import arrow.core.Right
@@ -7,6 +7,8 @@ import arrow.core.extensions.`try`.applicative.applicative
 import arrow.core.extensions.either.applicative.applicative
 import arrow.core.fix
 import arrow.core.Validated
+import arrow.optics.toEither
+import arrow.optics.toTry
 import arrow.test.UnitSpec
 import arrow.test.generators.`try`
 import arrow.test.generators.either


### PR DESCRIPTION
Original PR can be seen [here](https://github.com/arrow-kt/arrow-core/issues/26).

What version are you currently using? 0.10

What would you like to see?
The documentation includes Try examples. Since Try is deprecated, these examples should be removed (or transitioned to Either examples) to prevent confusion.