### PR TITLE
Remove binary-compatibility-validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,5 @@
 buildscript {
     apply from: "$COMMON_SETUP"
-    dependencies {
-        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$KOTLINX_VALIDATOR_VERSION"
-    }
 }
 
 plugins {
@@ -17,12 +14,6 @@ plugins {
 }
 
 apply from: "$GENERIC_CONF"
-
-apply plugin: 'binary-compatibility-validator'
-
-apiValidation {
-    ignoredProjects += ["arrow-docs", "arrow-optics-test"]
-}
 
 subprojects {
     apply plugin: 'ru.vyarus.animalsniffer'


### PR DESCRIPTION
Remove binary-compatibility-validator because is automatically checking the api