### PR TITLE
Remove Functor#unit usage

### DIFF
--- a/arrow-docs/src/main/kotlin/RecursionHelper.kt
+++ b/arrow-docs/src/main/kotlin/RecursionHelper.kt
@@ -60,7 +60,7 @@ fun <A, B> lift(arg0: Function1<A, B>): Function1<Kind<ForIntListPattern, A>, Ki
   "EXTENSION_SHADOWED_BY_MEMBER"
 )
 fun <A> Kind<ForIntListPattern, A>.void(): IntListPattern<Unit> = IntListPattern.functor().run {
-  unit<A>() as IntListPattern<kotlin.Unit>
+  void<A>() as IntListPattern<kotlin.Unit>
 }
 
 @JvmName("fproduct")

--- a/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
@@ -208,7 +208,7 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
    * Map each target to a Monoid and combine the results
    */
   fun <R> foldMap(M: Monoid<R>, s: S, f: (A) -> R): R =
-    modifyF(Const.applicative(M), s) { b -> Const(f(b)) }.value()
+    modifyF(Const.applicative(M), s) { b -> Const<R, B>(f(b)) }.value()
 
   /**
    * Fold using the given [Monoid] instance.


### PR DESCRIPTION
Removes `Functor#unit` usage as removed in https://github.com/arrow-kt/arrow-core/pull/267.