### PR TITLE
Deprecate higherkind types

### DIFF
--- a/arrow-optics/src/main/kotlin/arrow/optics/Fold.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Fold.kt
@@ -11,9 +11,20 @@ import arrow.core.extensions.AndMonoid
 import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.monoid
 import arrow.core.identity
-import arrow.higherkind
 import arrow.typeclasses.Foldable
 import arrow.typeclasses.Monoid
+
+@Deprecated(KindDeprecation)
+class ForFold private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias FoldOf<S, A> = arrow.Kind2<ForFold, S, A>
+@Deprecated(KindDeprecation)
+typealias FoldPartialOf<S> = arrow.Kind<ForFold, S>
+@Deprecated(KindDeprecation)
+typealias FoldKindedJ<S, A> = arrow.HkJ2<ForFold, S, A>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, A> FoldOf<S, A>.fix(): Fold<S, A> = this as Fold<S, A>
 
 /**
  * A [Fold] is an optic that allows to focus into structure and get multiple results.
@@ -23,7 +34,6 @@ import arrow.typeclasses.Monoid
  * @param S the source of a [Fold]
  * @param A the target of a [Fold]
  */
-@higherkind
 interface Fold<S, A> : FoldOf<S, A> {
 
   /**

--- a/arrow-optics/src/main/kotlin/arrow/optics/Getter.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Getter.kt
@@ -8,8 +8,19 @@ import arrow.core.Tuple2
 import arrow.core.compose
 import arrow.core.identity
 import arrow.core.toT
-import arrow.higherkind
 import arrow.typeclasses.Monoid
+
+@Deprecated(KindDeprecation)
+class ForGetter private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias GetterOf<S, A> = arrow.Kind2<ForGetter, S, A>
+@Deprecated(KindDeprecation)
+typealias GetterPartialOf<S> = arrow.Kind<ForGetter, S>
+@Deprecated(KindDeprecation)
+typealias GetterKindedJ<S, A> = arrow.HkJ2<ForGetter, S, A>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, A> GetterOf<S, A>.fix(): Getter<S, A> = this as Getter<S, A>
 
 /**
  * A [Getter] is an optic that allows to see into a structure and getting a focus.
@@ -20,7 +31,6 @@ import arrow.typeclasses.Monoid
  * @param S the source of a [Getter]
  * @param A the focus of a [Getter]
  */
-@higherkind
 interface Getter<S, A> : GetterOf<S, A> {
 
   /**

--- a/arrow-optics/src/main/kotlin/arrow/optics/Iso.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Iso.kt
@@ -9,10 +9,22 @@ import arrow.core.Tuple2
 import arrow.core.compose
 import arrow.core.identity
 import arrow.core.toT
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monoid
+
+@Deprecated(KindDeprecation)
+class ForPIso private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias PIsoOf<S, T, A, B> = arrow.Kind4<ForPIso, S, T, A, B>
+@Deprecated(KindDeprecation)
+typealias PIsoPartialOf<S, T, A> = arrow.Kind3<ForPIso, S, T, A>
+@Deprecated(KindDeprecation)
+typealias PIsoKindedJ<S, T, A, B> = arrow.HkJ4<ForPIso, S, T, A, B>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, T, A, B> PIsoOf<S, T, A, B>.fix(): PIso<S, T, A, B> =
+  this as PIso<S, T, A, B>
 
 /**
  * [Iso] is a type alias for [PIso] which fixes the type arguments
@@ -39,7 +51,6 @@ typealias IsoKindedJ<S, A> = PIsoKindedJ<S, S, A, A>
  * @param A the focus of a [PIso]
  * @param B the modified target of a [PIso]
  */
-@higherkind
 interface PIso<S, T, A, B> : PIsoOf<S, T, A, B> {
 
   /**

--- a/arrow-optics/src/main/kotlin/arrow/optics/Lens.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Lens.kt
@@ -8,10 +8,22 @@ import arrow.core.Some
 import arrow.core.Tuple2
 import arrow.core.identity
 import arrow.core.toT
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Functor
 import arrow.typeclasses.Monoid
+
+@Deprecated(KindDeprecation)
+class ForPLens private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias PLensOf<S, T, A, B> = arrow.Kind4<ForPLens, S, T, A, B>
+@Deprecated(KindDeprecation)
+typealias PLensPartialOf<S, T, A> = arrow.Kind3<ForPLens, S, T, A>
+@Deprecated(KindDeprecation)
+typealias PLensKindedJ<S, T, A, B> = arrow.HkJ4<ForPLens, S, T, A, B>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, T, A, B> PLensOf<S, T, A, B>.fix(): PLens<S, T, A, B> =
+  this as PLens<S, T, A, B>
 
 /**
  * [Lens] is a type alias for [PLens] which fixes the type arguments
@@ -40,7 +52,6 @@ typealias LensKindedJ<S, A> = PLensKindedJ<S, S, A, A>
  * @param A the focus of a [PLens]
  * @param B the modified focus of a [PLens]
  */
-@higherkind
 interface PLens<S, T, A, B> : PLensOf<S, T, A, B> {
 
   fun get(s: S): A

--- a/arrow-optics/src/main/kotlin/arrow/optics/Optional.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Optional.kt
@@ -10,9 +10,21 @@ import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.identity
 import arrow.core.toT
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monoid
+
+@Deprecated(KindDeprecation)
+class ForPOptional private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias POptionalOf<S, T, A, B> = arrow.Kind4<ForPOptional, S, T, A, B>
+@Deprecated(KindDeprecation)
+typealias POptionalPartialOf<S, T, A> = arrow.Kind3<ForPOptional, S, T, A>
+@Deprecated(KindDeprecation)
+typealias POptionalKindedJ<S, T, A, B> = arrow.HkJ4<ForPOptional, S, T, A, B>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, T, A, B> POptionalOf<S, T, A, B>.fix(): POptional<S, T, A, B> =
+  this as POptional<S, T, A, B>
 
 /**
  * [Optional] is a type alias for [POptional] which fixes the type arguments
@@ -67,7 +79,6 @@ fun <S, A> Optional(getOption: (source: S) -> Option<A>, set: (source: S, focus:
  * @param A the focus of a [POptional]
  * @param B the modified focus of a [POptional]
  */
-@higherkind
 interface POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
 
   /**

--- a/arrow-optics/src/main/kotlin/arrow/optics/Prism.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Prism.kt
@@ -11,10 +11,22 @@ import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.identity
 import arrow.core.toT
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Eq
 import arrow.typeclasses.Monoid
+
+@Deprecated(KindDeprecation)
+class ForPPrism private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias PPrismOf<S, T, A, B> = arrow.Kind4<ForPPrism, S, T, A, B>
+@Deprecated(KindDeprecation)
+typealias PPrismPartialOf<S, T, A> = arrow.Kind3<ForPPrism, S, T, A>
+@Deprecated(KindDeprecation)
+typealias PPrismKindedJ<S, T, A, B> = arrow.HkJ4<ForPPrism, S, T, A, B>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, T, A, B> PPrismOf<S, T, A, B>.fix(): PPrism<S, T, A, B> =
+  this as PPrism<S, T, A, B>
 
 /**
  * [Prism] is a type alias for [PPrism] which fixes the type arguments
@@ -43,7 +55,6 @@ typealias PrismKindedJ<S, A> = PPrismKindedJ<S, S, A, A>
  * @param A the focus of a [PPrism]
  * @param B the modified focus of a [PPrism]
  */
-@higherkind
 interface PPrism<S, T, A, B> : PPrismOf<S, T, A, B> {
 
   fun getOrModify(s: S): Either<T, A>

--- a/arrow-optics/src/main/kotlin/arrow/optics/Setter.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Setter.kt
@@ -2,8 +2,20 @@ package arrow.optics
 
 import arrow.Kind
 import arrow.core.Either
-import arrow.higherkind
 import arrow.typeclasses.Functor
+
+@Deprecated(KindDeprecation)
+class ForPSetter private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias PSetterOf<S, T, A, B> = arrow.Kind4<ForPSetter, S, T, A, B>
+@Deprecated(KindDeprecation)
+typealias PSetterPartialOf<S, T, A> = arrow.Kind3<ForPSetter, S, T, A>
+@Deprecated(KindDeprecation)
+typealias PSetterKindedJ<S, T, A, B> = arrow.HkJ4<ForPSetter, S, T, A, B>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, T, A, B> PSetterOf<S, T, A, B>.fix(): PSetter<S, T, A, B> =
+  this as PSetter<S, T, A, B>
 
 /**
  * [Setter] is a type alias for [PSetter] which fixes the type arguments
@@ -31,7 +43,6 @@ typealias SetterKindedJ<S, A> = PSetterKindedJ<S, S, A, A>
  * @param A the focus of a [PSetter]
  * @param B the modified focus of a [PSetter]
  */
-@higherkind
 interface PSetter<S, T, A, B> : PSetterOf<S, T, A, B> {
 
   /**

--- a/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
@@ -15,10 +15,22 @@ import arrow.core.extensions.listk.monoid.monoid
 import arrow.core.extensions.monoid
 import arrow.core.identity
 import arrow.core.value
-import arrow.higherkind
 import arrow.typeclasses.Applicative
 import arrow.typeclasses.Monoid
 import arrow.typeclasses.Traverse
+
+@Deprecated(KindDeprecation)
+class ForPTraversal private constructor() { companion object }
+@Deprecated(KindDeprecation)
+typealias PTraversalOf<S, T, A, B> = arrow.Kind4<ForPTraversal, S, T, A, B>
+@Deprecated(KindDeprecation)
+typealias PTraversalPartialOf<S, T, A> = arrow.Kind3<ForPTraversal, S, T, A>
+@Deprecated(KindDeprecation)
+typealias PTraversalKindedJ<S, T, A, B> = arrow.HkJ4<ForPTraversal, S, T, A, B>
+@Suppress("UNCHECKED_CAST", "NOTHING_TO_INLINE")
+@Deprecated(KindDeprecation)
+inline fun <S, T, A, B> PTraversalOf<S, T, A, B>.fix(): PTraversal<S, T, A, B> =
+  this as PTraversal<S, T, A, B>
 
 /**
  * [Traversal] is a type alias for [PTraversal] which fixes the type arguments
@@ -42,7 +54,6 @@ typealias TraversalKindedJ<S, A> = PTraversalKindedJ<S, S, A, A>
  * @param A the target of a [PTraversal]
  * @param B the modified target of a [PTraversal]
  */
-@higherkind
 interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
 
   fun <F> modifyF(FA: Applicative<F>, s: S, f: (A) -> Kind<F, B>): Kind<F, T>

--- a/arrow-optics/src/main/kotlin/arrow/optics/hks.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/hks.kt
@@ -1,0 +1,5 @@
+package arrow.optics
+
+// TODO: Remove this message once it is added into arrow core
+const val KindDeprecation =
+  """Higher Kinded types and their related type classes will no longer be supported after Arrow 0.13.0. Most relevant APIs are now concrete over the data types available as members or top level extension functions"""


### PR DESCRIPTION
This PR deprecates the higher-kinded types and remove the @higherkind annotation as part of the process to remove the Kind interface from the Arrow codebase.