### PR TITLE
Deprecate Each typeclass

### DIFF
--- a/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
@@ -367,4 +367,69 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
    * Check if forall targets satisfy the predicate
    */
   fun forall(s: S, p: (A) -> Boolean): Boolean = foldMap(s, p, AndMonoid)
+
+  /**
+   * DSL to compose [Traversal] with a [Lens] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Lens] with a focus in [S]
+   * @return [Traversal] with a focus in [A]
+   */
+  val <U, V> PLens<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
+    this@every.compose(this@PTraversal)
+
+  /**
+   * DSL to compose [Traversal] with a [Iso] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Iso] with a focus in [S]
+   * @return [Traversal] with a focus in [A]
+   */
+  val <U, V> PIso<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
+    this@every.compose(this@PTraversal)
+
+  /**
+   * DSL to compose [Traversal] with a [Prism] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Prism] with a focus in [S]
+   * @return [Traversal] with a focus in [A]
+   */
+  val <U, V> PPrism<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
+  this.compose(this@PTraversal)
+
+  /**
+   * DSL to compose [Traversal] with a [Optional] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Optional] with a focus in [S]
+   * @return [Traversal] with a focus in [A]
+   */
+  @Suppress("UNCHECKED_CAST")
+  val <U, V> POptional<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
+    this.compose(this@PTraversal)
+
+  /**
+   * DSL to compose [Traversal] with a [Setter] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Setter] with a focus in [S]
+   * @return [Setter] with a focus in [A]
+   */
+  @Suppress("UNCHECKED_CAST")
+  val <U, V> PSetter<U, V, S, T>.every: PSetter<U, V, A, B> get() =
+    this.compose(this@PTraversal)
+
+  /**
+   * DSL to compose [Traversal] with a [Traversal] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Traversal] with a focus in [S]
+   * @return [Traversal] with a focus in [A]
+   */
+  @Suppress("UNCHECKED_CAST")
+  val <U, V> PTraversal<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
+    this.compose(this@PTraversal)
+
+  /**
+   * DSL to compose [Traversal] with a [Fold] for a structure [S] to see all its foci [A]
+   *
+   * @receiver [Fold] with a focus in [S]
+   * @return [Fold] with a focus in [A]
+   */
+  val <U> Fold<U, S>.every: Fold<U, A> get() = this.compose(this@PTraversal.asFold())
 }

--- a/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
@@ -401,7 +401,6 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
    * @receiver [Optional] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
-  @Suppress("UNCHECKED_CAST")
   val <U, V> POptional<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
     this.compose(this@PTraversal)
 
@@ -411,7 +410,6 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
    * @receiver [Setter] with a focus in [S]
    * @return [Setter] with a focus in [A]
    */
-  @Suppress("UNCHECKED_CAST")
   val <U, V> PSetter<U, V, S, T>.every: PSetter<U, V, A, B> get() =
     this.compose(this@PTraversal)
 
@@ -421,7 +419,6 @@ interface PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
    * @receiver [Traversal] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
-  @Suppress("UNCHECKED_CAST")
   val <U, V> PTraversal<U, V, S, T>.every: PTraversal<U, V, A, B> get() =
     this.compose(this@PTraversal)
 

--- a/arrow-optics/src/main/kotlin/arrow/optics/dsl/each.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/dsl/each.kt
@@ -16,6 +16,11 @@ import arrow.optics.typeclasses.Each
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Traversal] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Lens<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(EA.each())
 
 /**
@@ -25,6 +30,11 @@ fun <T, S, A> Lens<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(E
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Traversal] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Iso<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(EA.each())
 
 /**
@@ -34,6 +44,11 @@ fun <T, S, A> Iso<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(EA
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Traversal] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Prism<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(EA.each())
 
 /**
@@ -43,6 +58,11 @@ fun <T, S, A> Prism<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Traversal] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Optional<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(EA.each())
 
 /**
@@ -52,6 +72,11 @@ fun <T, S, A> Optional<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compo
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Setter] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Setter<T, S>.every(EA: Each<S, A>): Setter<T, A> = this.compose(EA.each())
 
 /**
@@ -61,6 +86,11 @@ fun <T, S, A> Setter<T, S>.every(EA: Each<S, A>): Setter<T, A> = this.compose(EA
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Traversal] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Traversal<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.compose(EA.each())
 
 /**
@@ -70,4 +100,9 @@ fun <T, S, A> Traversal<T, S>.every(EA: Each<S, A>): Traversal<T, A> = this.comp
  * @param EA [Each] to provide [Traversal] that can focus into a structure [S] to see all its foci [A]
  * @return [Fold] with a focus in [A]
  */
+@Deprecated(
+  "Each is being deprecated. Use Traversal directly instead.",
+  ReplaceWith("every(TR: Traversal<S, A>)", "arrow.optics.Traversal"),
+  DeprecationLevel.WARNING
+)
 fun <T, S, A> Fold<T, S>.every(EA: Each<S, A>): Fold<T, A> = this.compose(EA.each())

--- a/arrow-optics/src/main/kotlin/arrow/optics/dsl/every.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/dsl/every.kt
@@ -1,0 +1,72 @@
+package arrow.optics.dsl
+
+import arrow.optics.Fold
+import arrow.optics.Iso
+import arrow.optics.Lens
+import arrow.optics.Optional
+import arrow.optics.Prism
+import arrow.optics.Setter
+import arrow.optics.Traversal
+
+/**
+ * DSL to compose [Traversal] with a [Lens] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Lens] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Traversal] with a focus in [A]
+ */
+fun <T, S, A> Lens<T, S>.every(TR: Traversal<S, A>): Traversal<T, A> = this.compose(TR)
+
+/**
+ * DSL to compose [Traversal] with an [Iso] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Iso] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Traversal] with a focus in [A]
+ */
+fun <T, S, A> Iso<T, S>.every(TR: Traversal<S, A>): Traversal<T, A> = this.compose(TR)
+
+/**
+ * DSL to compose [Traversal] with a [Prism] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Prism] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Traversal] with a focus in [A]
+ */
+fun <T, S, A> Prism<T, S>.every(TR: Traversal<S, A>): Traversal<T, A> = this.compose(TR)
+
+/**
+ * DSL to compose [Traversal] with an [Optional] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Optional] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Traversal] with a focus in [A]
+ */
+fun <T, S, A> Optional<T, S>.every(TR: Traversal<S, A>): Traversal<T, A> = this.compose(TR)
+
+/**
+ * DSL to compose [Traversal] with a [Setter] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Setter] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Setter] with a focus in [A]
+ */
+fun <T, S, A> Setter<T, S>.every(TR: Traversal<S, A>): Setter<T, A> = this.compose(TR)
+
+/**
+ * DSL to compose [Traversal] with a [Traversal] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Traversal] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Traversal] with a focus in [A]
+ */
+fun <T, S, A> Traversal<T, S>.every(TR: Traversal<S, A>): Traversal<T, A> = this.compose(TR)
+
+/**
+ * DSL to compose [Traversal] with a [Fold] for a structure [S] to see all its foci [A]
+ *
+ * @receiver [Fold] with a focus in [S]
+ * @param TR [Traversal] that can focus into a structure [S] to see all its foci [A]
+ * @return [Fold] with a focus in [A]
+ */
+fun <T, S, A> Fold<T, S>.every(TR: Traversal<S, A>): Fold<T, A> = this.compose(TR)

--- a/arrow-optics/src/main/kotlin/arrow/optics/typeclasses/Each.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/typeclasses/Each.kt
@@ -18,6 +18,7 @@ import arrow.typeclasses.Traverse
  * @param S source of the [Traversal]
  * @param A focus of [Traversal]
  */
+@Deprecated("Each is being deprecated. Use Traversal directly instead.")
 fun interface Each<S, A> {
 
   /**
@@ -33,6 +34,7 @@ fun interface Each<S, A> {
    * @receiver [Lens] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Lens<T, S>.every: Traversal<T, A> get() = this.compose(each())
 
   /**
@@ -41,6 +43,7 @@ fun interface Each<S, A> {
    * @receiver [Iso] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Iso<T, S>.every: Traversal<T, A> get() = this.compose(each())
 
   /**
@@ -49,6 +52,7 @@ fun interface Each<S, A> {
    * @receiver [Prism] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Prism<T, S>.every: Traversal<T, A> get() = this.compose(each())
 
   /**
@@ -57,6 +61,7 @@ fun interface Each<S, A> {
    * @receiver [Optional] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Optional<T, S>.every: Traversal<T, A> get() = this.compose(each())
 
   /**
@@ -65,6 +70,7 @@ fun interface Each<S, A> {
    * @receiver [Setter] with a focus in [S]
    * @return [Setter] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Setter<T, S>.every: Setter<T, A> get() = this.compose(each())
 
   /**
@@ -73,6 +79,7 @@ fun interface Each<S, A> {
    * @receiver [Traversal] with a focus in [S]
    * @return [Traversal] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Traversal<T, S>.every: Traversal<T, A> get() = this.compose(each())
 
   /**
@@ -81,6 +88,7 @@ fun interface Each<S, A> {
    * @receiver [Fold] with a focus in [S]
    * @return [Fold] with a focus in [A]
    */
+  @Deprecated("Each is being deprecated. Use Traversal directly instead.")
   val <T> Fold<T, S>.every: Fold<T, A> get() = this.compose(each())
 
   companion object {

--- a/arrow-optics/src/test/kotlin/arrow/optics/DSLTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/DSLTest.kt
@@ -7,7 +7,6 @@ import arrow.core.k
 import arrow.optics.dsl.at
 import arrow.optics.extensions.listk.index.index
 import arrow.optics.extensions.mapk.at.at
-import arrow.optics.extensions.mapk.each.each
 import arrow.optics.extensions.traversal
 import arrow.core.test.UnitSpec
 import io.kotlintest.shouldBe
@@ -102,8 +101,8 @@ class BoundedTest : UnitSpec() {
       } shouldBe (Db.content compose MapK.at<Keys, String>().at(One)).set(db, None)
     }
 
-    "Working with Each in Optics should be same as in DSL" {
-      MapK.each<Keys, String>().run {
+    "Working with Traversal in Optics should be same as in DSL" {
+      MapK.traversal<Keys, String>().run {
         Db.content.every.modify(db, String::toUpperCase)
       } shouldBe (Db.content compose MapK.traversal()).modify(db, String::toUpperCase)
     }

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/ListInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/ListInstanceTest.kt
@@ -1,25 +1,24 @@
 package arrow.optics.instances
 
 import arrow.core.ListExtensions
+import arrow.core.ListK
 import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.extensions.eq
-import arrow.core.ListK
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.tuple2.eq.eq
-import arrow.optics.extensions.each
-import arrow.optics.extensions.filterIndex
-import arrow.optics.extensions.index
-import arrow.optics.extensions.listk.cons.cons
-import arrow.optics.extensions.listk.each.each
-import arrow.optics.extensions.listk.filterIndex.filterIndex
-import arrow.optics.extensions.listk.index.index
-import arrow.optics.extensions.listk.snoc.snoc
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.listK
 import arrow.core.test.generators.tuple2
+import arrow.optics.extensions.filterIndex
+import arrow.optics.extensions.index
+import arrow.optics.extensions.listk.cons.cons
+import arrow.optics.extensions.listk.filterIndex.filterIndex
+import arrow.optics.extensions.listk.index.index
+import arrow.optics.extensions.listk.snoc.snoc
+import arrow.optics.extensions.traversal
 import arrow.optics.test.laws.OptionalLaws
 import arrow.optics.test.laws.PrismLaws
 import arrow.optics.test.laws.TraversalLaws
@@ -32,7 +31,7 @@ class ListInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = ListK.each<String>().each(),
+        traversal = ListK.traversal(),
         aGen = Gen.listK(Gen.string()),
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),
@@ -44,7 +43,7 @@ class ListInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = ListExtensions.each<String>().each(),
+        traversal = ListExtensions.traversal(),
         aGen = Gen.list(Gen.string()),
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/MapInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/MapInstanceTest.kt
@@ -1,28 +1,27 @@
 package arrow.optics.instances
 
+import arrow.core.ListK
 import arrow.core.MapInstances
+import arrow.core.MapK
 import arrow.core.Option
+import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.monoid
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.option.monoid.monoid
 import arrow.core.extensions.semigroup
-import arrow.core.ListK
-import arrow.core.MapK
-import arrow.core.extensions.listk.eq.eq
-import arrow.optics.extensions.at
-import arrow.optics.extensions.each
-import arrow.optics.extensions.filterIndex
-import arrow.optics.extensions.index
-import arrow.optics.extensions.mapk.at.at
-import arrow.optics.extensions.mapk.each.each
-import arrow.optics.extensions.mapk.filterIndex.filterIndex
-import arrow.optics.extensions.mapk.index.index
-import arrow.optics.test.generators.char
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.intSmall
 import arrow.core.test.generators.mapK
 import arrow.core.test.generators.option
+import arrow.optics.extensions.at
+import arrow.optics.extensions.filterIndex
+import arrow.optics.extensions.index
+import arrow.optics.extensions.mapk.at.at
+import arrow.optics.extensions.mapk.filterIndex.filterIndex
+import arrow.optics.extensions.mapk.index.index
+import arrow.optics.extensions.traversal
+import arrow.optics.test.generators.char
 import arrow.optics.test.laws.LensLaws
 import arrow.optics.test.laws.OptionalLaws
 import arrow.optics.test.laws.TraversalLaws
@@ -35,7 +34,7 @@ class MapInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = MapK.each<Int, String>().each(),
+        traversal = MapK.traversal(),
         aGen = Gen.mapK(Gen.int(), Gen.string()),
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),
@@ -47,7 +46,7 @@ class MapInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = MapInstances.each<Int, String>().each(),
+        traversal = MapInstances.traversal(),
         aGen = Gen.map(Gen.int(), Gen.string()),
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/NonEmptyListInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/NonEmptyListInstanceTest.kt
@@ -1,16 +1,16 @@
 package arrow.optics.instances
 
-import arrow.core.Option
 import arrow.core.ListK
 import arrow.core.NonEmptyList
+import arrow.core.Option
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
-import arrow.optics.extensions.nonemptylist.each.each
-import arrow.optics.extensions.nonemptylist.filterIndex.filterIndex
-import arrow.optics.extensions.nonemptylist.index.index
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.nonEmptyList
+import arrow.optics.extensions.nonemptylist.filterIndex.filterIndex
+import arrow.optics.extensions.nonemptylist.index.index
+import arrow.optics.extensions.traversal
 import arrow.optics.test.laws.OptionalLaws
 import arrow.optics.test.laws.TraversalLaws
 import arrow.typeclasses.Eq
@@ -22,7 +22,7 @@ class NonEmptyListInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = NonEmptyList.each<String>().each(),
+        traversal = NonEmptyList.traversal(),
         aGen = Gen.nonEmptyList(Gen.string()),
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/OptionInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/OptionInstanceTest.kt
@@ -1,13 +1,13 @@
 package arrow.optics.instances
 
-import arrow.core.Option
 import arrow.core.ListK
+import arrow.core.Option
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
-import arrow.optics.extensions.option.each.each
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.option
+import arrow.optics.extensions.traversal
 import arrow.optics.test.laws.TraversalLaws
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
@@ -17,7 +17,7 @@ class OptionInstanceTest : UnitSpec() {
   init {
 
     testLaws(TraversalLaws.laws(
-      traversal = Option.each<String>().each(),
+      traversal = Option.traversal(),
       aGen = Gen.option(Gen.string()),
       bGen = Gen.string(),
       funcGen = Gen.functionAToB(Gen.string()),

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/SequenceKInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/SequenceKInstanceTest.kt
@@ -1,18 +1,18 @@
 package arrow.optics.instances
 
-import arrow.core.Option
-import arrow.core.extensions.eq
 import arrow.core.ListK
+import arrow.core.Option
 import arrow.core.SequenceK
+import arrow.core.extensions.eq
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.sequencek.eq.eq
-import arrow.optics.extensions.sequencek.each.each
-import arrow.optics.extensions.sequencek.filterIndex.filterIndex
-import arrow.optics.extensions.sequencek.index.index
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.sequenceK
+import arrow.optics.extensions.sequencek.filterIndex.filterIndex
+import arrow.optics.extensions.sequencek.index.index
+import arrow.optics.extensions.traversal
 import arrow.optics.test.laws.OptionalLaws
 import arrow.optics.test.laws.TraversalLaws
 import io.kotlintest.properties.Gen
@@ -23,7 +23,7 @@ class SequenceKInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = SequenceK.each<String>().each(),
+        traversal = SequenceK.traversal(),
         aGen = Gen.sequenceK(Gen.string()),
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/StringInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/StringInstanceTest.kt
@@ -1,21 +1,21 @@
 package arrow.optics.instances
 
+import arrow.core.ListK
 import arrow.core.Option
 import arrow.core.Tuple2
 import arrow.core.extensions.eq
-import arrow.core.ListK
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.tuple2.eq.eq
-import arrow.optics.extensions.cons
-import arrow.optics.extensions.each
-import arrow.optics.extensions.filterIndex
-import arrow.optics.extensions.index
-import arrow.optics.extensions.snoc
-import arrow.optics.test.generators.char
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.tuple2
+import arrow.optics.extensions.cons
+import arrow.optics.extensions.filterIndex
+import arrow.optics.extensions.index
+import arrow.optics.extensions.snoc
+import arrow.optics.extensions.traversal
+import arrow.optics.test.generators.char
 import arrow.optics.test.laws.OptionalLaws
 import arrow.optics.test.laws.PrismLaws
 import arrow.optics.test.laws.TraversalLaws
@@ -28,7 +28,7 @@ class StringInstanceTest : UnitSpec() {
 
     testLaws(
       TraversalLaws.laws(
-        traversal = String.each().each(),
+        traversal = String.traversal(),
         aGen = Gen.string(),
         bGen = Gen.char(),
         funcGen = Gen.functionAToB(Gen.char()),


### PR DESCRIPTION
As discussed in this [PR](https://github.com/arrow-kt/arrow-optics/pull/79#pullrequestreview-563469420), we're deprecating `Each` typeclass in favor of `Traversal` since `Each` simply summons a `Traversal` without any other benefit.