### PR TITLE
Move instances to typeclasses companion object

### DIFF
--- a/arrow-optics/src/main/kotlin/arrow/optics/extensions/either/each/EitherEach.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/extensions/either/each/EitherEach.kt
@@ -26,7 +26,10 @@ internal val each_singleton: Each<Either<Any?, Any?>, Any?> = eitherEach()
 )
 @Deprecated(
   "Each is being deprecated. Use Traversal directly instead.",
-  ReplaceWith("Either.traversal<L, R>()", "arrow.core.Either", "arrow.optics.traversal"),
+  ReplaceWith(
+    "Traversal.either<L, R>()",
+    "arrow.optics.Traversal", "arrow.optics.either"
+  ),
   DeprecationLevel.WARNING
 )
 fun <L, R> each(): PTraversal<Either<L, R>, Either<L, R>, R, R> = arrow.core.Either
@@ -39,7 +42,10 @@ fun <L, R> each(): PTraversal<Either<L, R>, Either<L, R>, R, R> = arrow.core.Eit
 )
 @Deprecated(
   "Each is being deprecated. Use Traversal directly instead.",
-  ReplaceWith("Either.traversal<L, R>()", "arrow.core.Either", "arrow.optics.traversal"),
+  ReplaceWith(
+    "Traversal.either<L, R>()",
+    "arrow.optics.Traversal", "arrow.optics.either"
+  ),
   DeprecationLevel.WARNING)
 inline fun <L, R> Companion.each(): Each<Either<L, R>, R> = each_singleton as
     arrow.optics.typeclasses.Each<Either<L, R>, R>

--- a/arrow-optics/src/main/kotlin/arrow/optics/extensions/option/each/OptionEach.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/extensions/option/each/OptionEach.kt
@@ -27,8 +27,8 @@ internal val each_singleton: Each<Option<Any?>, Any?> = optionEach()
 @Deprecated(
   "Each is being deprecated. Use Traversal directly instead.",
   ReplaceWith(
-  "Option.traversal<A>()",
-  "arrow.core.Option", "arrow.optics.traversal"
+  "Traversal.option<A>()",
+  "arrow.optics.traversal", "arrow.optics.option"
   ),
   DeprecationLevel.WARNING
 )
@@ -43,8 +43,8 @@ fun <A> each(): PTraversal<Option<A>, Option<A>, A, A> = arrow.core.Option
 @Deprecated(
   "Each is being deprecated. Use Traversal directly instead.",
   ReplaceWith(
-    "Option.traversal<A>()",
-    "arrow.core.Option", "arrow.optics.traversal"
+    "Traversal.option<A>()",
+    "arrow.optics.traversal", "arrow.optics.option"
   ),
   DeprecationLevel.WARNING
 )

--- a/arrow-optics/src/main/kotlin/arrow/optics/std/either.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/std/either.kt
@@ -25,10 +25,10 @@ fun <A, B> Either.Companion.toValidated(): Iso<Either<A, B>, Validated<A, B>> = 
 /**
  * [Traversal] for [Either] that has focus in each [Either.Right].
  *
- * @receiver [Either.Companion] to make it statically available.
+ * @receiver [Traversal.Companion] to make it statically available.
  * @return [Traversal] with source [Either] and focus every [Either.Right] of the source.
  */
-fun <L, R> Either.Companion.traversal(): Traversal<Either<L, R>, R> =
+fun <L, R> PTraversal.Companion.either(): Traversal<Either<L, R>, R> =
   object : Traversal<Either<L, R>, R> {
     override fun <F> modifyF(FA: Applicative<F>, s: Either<L, R>, f: (R) -> Kind<F, R>): Kind<F, Either<L, R>> =
       with(Either.traverse<L>()) {

--- a/arrow-optics/src/main/kotlin/arrow/optics/std/option.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/std/option.kt
@@ -60,10 +60,10 @@ fun <A> Option.Companion.toEither(): Iso<Option<A>, Either<Unit, A>> = toPEither
 /**
  * [Traversal] for [Option] that has focus in each [arrow.core.Some].
  *
- * @receiver [Option.Companion] to make it statically available.
+ * @receiver [PTraversal.Companion] to make it statically available.
  * @return [Traversal] with source [Option] and focus in every [arrow.core.Some] of the source.
  */
-fun <A> Option.Companion.traversal(): Traversal<Option<A>, A> =
+fun <A> PTraversal.Companion.option(): Traversal<Option<A>, A> =
   object : Traversal<Option<A>, A> {
     override fun <F> modifyF(FA: Applicative<F>, s: Option<A>, f: (A) -> Kind<F, A>): Kind<F, Option<A>> =
       with(Option.traverse()) {

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/EitherInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/EitherInstanceTest.kt
@@ -1,6 +1,5 @@
 package arrow.optics.instances
 
-import arrow.core.Either
 import arrow.core.Option
 import arrow.core.ListK
 import arrow.core.extensions.listk.eq.eq
@@ -8,8 +7,9 @@ import arrow.core.extensions.option.eq.eq
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.either
 import arrow.core.test.generators.functionAToB
+import arrow.optics.Traversal
+import arrow.optics.either
 import arrow.optics.test.laws.TraversalLaws
-import arrow.optics.traversal
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 
@@ -18,7 +18,7 @@ class EitherInstanceTest : UnitSpec() {
   init {
 
     testLaws(TraversalLaws.laws(
-      traversal = Either.traversal(),
+      traversal = Traversal.either(),
       aGen = Gen.either(Gen.string(), Gen.int()),
       bGen = Gen.int(),
       funcGen = Gen.functionAToB(Gen.int()),

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/OptionInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/OptionInstanceTest.kt
@@ -1,14 +1,15 @@
 package arrow.optics.instances
 
-import arrow.core.Option
 import arrow.core.ListK
+import arrow.core.Option
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.option
+import arrow.optics.Traversal
+import arrow.optics.option
 import arrow.optics.test.laws.TraversalLaws
-import arrow.optics.traversal
 import arrow.typeclasses.Eq
 import io.kotlintest.properties.Gen
 
@@ -17,7 +18,7 @@ class OptionInstanceTest : UnitSpec() {
   init {
 
     testLaws(TraversalLaws.laws(
-      traversal = Option.traversal<String>(),
+      traversal = Traversal.option(),
       aGen = Gen.option(Gen.string()),
       bGen = Gen.string(),
       funcGen = Gen.functionAToB(Gen.string()),


### PR DESCRIPTION
We cannot guarantee that all data types have a Companion object, but we can guarantee that a typeclass has a Companion. For consistency reason, it's, therefore, most interesting to expose instances on the Companion of the typeclass.

This PR moves the new code that exposes the typeclasses to the typeclass Companion.