### PR TITLE
Reverting changes for Either and Option extension methods

### DIFF
--- a/arrow-optics/src/main/kotlin/arrow/optics/extensions/either.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/extensions/either.kt
@@ -31,4 +31,7 @@ fun <L, R> Either.Companion.traversal(): Traversal<Either<L, R>, R> = object : T
   "Each is being deprecated. Use Traversal directly instead.",
   ReplaceWith("Either.traversal<L, R>()", "arrow.core.Either", "arrow.optics.traversal"),
   DeprecationLevel.WARNING)
-fun <L, R> eitherEach(): Each<Either<L, R>, R> = Each { Either.traversal() }
+interface EitherEach<L, R> : Each<Either<L, R>, R> {
+  override fun each(): Traversal<Either<L, R>, R> =
+    Either.traversal()
+}

--- a/arrow-optics/src/main/kotlin/arrow/optics/extensions/either/each/EitherEach.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/extensions/either/each/EitherEach.kt
@@ -3,19 +3,13 @@ package arrow.optics.extensions.either.each
 import arrow.core.Either
 import arrow.core.Either.Companion
 import arrow.optics.PTraversal
-import arrow.optics.extensions.eitherEach
-import arrow.optics.typeclasses.Each
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
+import arrow.optics.extensions.EitherEach
 
 /**
  * cached extension
  */
 @PublishedApi()
-internal val each_singleton: Each<Either<Any?, Any?>, Any?> = eitherEach()
+internal val each_singleton: EitherEach<Any?, Any?> = object : EitherEach<Any?, Any?> {}
 
 @JvmName("each")
 @Suppress(
@@ -47,5 +41,5 @@ fun <L, R> each(): PTraversal<Either<L, R>, Either<L, R>, R, R> = arrow.core.Eit
     "arrow.optics.Traversal", "arrow.optics.either"
   ),
   DeprecationLevel.WARNING)
-inline fun <L, R> Companion.each(): Each<Either<L, R>, R> = each_singleton as
-    arrow.optics.typeclasses.Each<Either<L, R>, R>
+inline fun <L, R> Companion.each(): EitherEach<L, R> = each_singleton as
+    arrow.optics.extensions.EitherEach<L, R>

--- a/arrow-optics/src/main/kotlin/arrow/optics/extensions/option.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/extensions/option.kt
@@ -38,4 +38,7 @@ fun <A> Option.Companion.traversal(): Traversal<Option<A>, A> = object : Travers
   ),
   DeprecationLevel.WARNING
 )
-fun <A> optionEach(): Each<Option<A>, A> = Each { Option.traversal() }
+interface OptionEach<A> : Each<Option<A>, A> {
+  override fun each(): Traversal<Option<A>, A> =
+    Option.traversal()
+}

--- a/arrow-optics/src/main/kotlin/arrow/optics/extensions/option/each/OptionEach.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/extensions/option/each/OptionEach.kt
@@ -3,19 +3,13 @@ package arrow.optics.extensions.option.each
 import arrow.core.Option
 import arrow.core.Option.Companion
 import arrow.optics.PTraversal
-import arrow.optics.extensions.optionEach
-import arrow.optics.typeclasses.Each
-import kotlin.Any
-import kotlin.Deprecated
-import kotlin.PublishedApi
-import kotlin.Suppress
-import kotlin.jvm.JvmName
+import arrow.optics.extensions.OptionEach
 
 /**
  * cached extension
  */
 @PublishedApi()
-internal val each_singleton: Each<Option<Any?>, Any?> = optionEach()
+internal val each_singleton: OptionEach<Any?> = object : OptionEach<Any?> {}
 
 @JvmName("each")
 @Suppress(
@@ -48,5 +42,5 @@ fun <A> each(): PTraversal<Option<A>, Option<A>, A, A> = arrow.core.Option
   ),
   DeprecationLevel.WARNING
 )
-inline fun <A> Companion.each(): Each<Option<A>, A> = each_singleton as
-    arrow.optics.typeclasses.Each<Option<A>, A>
+inline fun <A> Companion.each(): OptionEach<A> = each_singleton as
+    arrow.optics.extensions.OptionEach<A>


### PR DESCRIPTION
As part of the pull requests https://github.com/arrow-kt/arrow-optics/pull/79 and https://github.com/arrow-kt/arrow-optics/pull/80, we turned some interfaces into functions without deprecating them previously. This pull request reverts those modifications to avoid breaking changes.