### PR TITLE
Remove Eq.list usage

### DIFF
--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/ListInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/ListInstanceTest.kt
@@ -7,7 +7,6 @@ import arrow.core.extensions.eq
 import arrow.core.extensions.listk.eq.eq
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.tuple2.eq.eq
-import arrow.core.list
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.core.test.generators.listK
@@ -120,8 +119,8 @@ class ListInstanceTest : UnitSpec() {
         aGen = Gen.list(Gen.int()),
         bGen = Gen.tuple2(Gen.int(), Gen.list(Gen.int())),
         funcGen = Gen.functionAToB(Gen.tuple2(Gen.int(), Gen.list(Gen.int()))),
-        EQA = Eq.list(Int.eq()),
-        EQOptionB = Option.eq(Tuple2.eq(Int.eq(), Eq.list(Int.eq())))
+        EQA = Eq.any(),
+        EQOptionB = Option.eq(Tuple2.eq(Int.eq(), Eq.any()))
       )
     )
 
@@ -142,8 +141,8 @@ class ListInstanceTest : UnitSpec() {
         aGen = Gen.list(Gen.int()),
         bGen = Gen.tuple2(Gen.list(Gen.int()), Gen.int()),
         funcGen = Gen.functionAToB(Gen.tuple2(Gen.list(Gen.int()), Gen.int())),
-        EQA = Eq.list(Int.eq()),
-        EQOptionB = Option.eq(Tuple2.eq(Eq.list(Int.eq()), Int.eq()))
+        EQA = Eq.any(),
+        EQOptionB = Option.eq(Tuple2.eq(Eq.any(), Int.eq()))
       )
     )
   }

--- a/arrow-optics/src/test/kotlin/arrow/optics/instances/SequenceInstanceTest.kt
+++ b/arrow-optics/src/test/kotlin/arrow/optics/instances/SequenceInstanceTest.kt
@@ -5,7 +5,6 @@ import arrow.core.SequenceK
 import arrow.core.extensions.eq
 import arrow.core.extensions.option.eq.eq
 import arrow.core.extensions.sequencek.eq.eq
-import arrow.core.list
 import arrow.core.test.UnitSpec
 import arrow.core.test.generators.functionAToB
 import arrow.optics.Traversal
@@ -36,7 +35,7 @@ class SequenceInstanceTest : UnitSpec() {
         funcGen = Gen.functionAToB(Gen.string()),
         EQA = sequenceEq(String.eq()),
         EQOptionB = Option.eq(String.eq()),
-        EQListB = Eq.list(String.eq())
+        EQListB = Eq.any()
       )
     )
 
@@ -47,7 +46,7 @@ class SequenceInstanceTest : UnitSpec() {
         bGen = Gen.string(),
         funcGen = Gen.functionAToB(Gen.string()),
         EQA = sequenceEq(String.eq()),
-        EQListB = Eq.list(String.eq()),
+        EQListB = Eq.any(),
         EQOptionB = Option.eq(String.eq())
       )
     )


### PR DESCRIPTION
Updates Arrow Optics for PR in Arrrow Core: https://github.com/arrow-kt/arrow-core/pull/322

This PR deprecates `Eq` since Kotlin, and Kotlin's Std doesn't take `Eq` into account nor does Kotlin have the power to automatically derive or inject `Eq` anywhere. This makes `Eq` very cumbersome to work with, see [`Tuple10Eq.kt`](https://github.com/arrow-kt/arrow-core/compare/sv-deprecate-eq?expand=1#diff-71c97dda0b6a770b17e372fadc91f43578fe2e833d77959444cab6885fc000b8)

The use-cases of `Eq` seemed very limited and niche to us, so we've decided to exclude it from Arrow in 1.0.0. The common technique for this is to use data class, which automatically implements `equals()`.