### PR TITLE
Remove duplicated deprecation message for Higher Kinded Types

### DIFF
--- a/arrow-optics/src/main/kotlin/arrow/optics/Fold.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Fold.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Const
 import arrow.core.Either
 import arrow.core.ListK

--- a/arrow-optics/src/main/kotlin/arrow/optics/Getter.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Getter.kt
@@ -1,5 +1,6 @@
 package arrow.optics
 
+import arrow.KindDeprecation
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option

--- a/arrow-optics/src/main/kotlin/arrow/optics/Iso.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Iso.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option

--- a/arrow-optics/src/main/kotlin/arrow/optics/Lens.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Lens.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option

--- a/arrow-optics/src/main/kotlin/arrow/optics/Optional.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Optional.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option

--- a/arrow-optics/src/main/kotlin/arrow/optics/Prism.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Prism.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either
 import arrow.core.None
 import arrow.core.Option

--- a/arrow-optics/src/main/kotlin/arrow/optics/Setter.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Setter.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Either
 import arrow.typeclasses.Functor
 

--- a/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/Traversal.kt
@@ -1,6 +1,7 @@
 package arrow.optics
 
 import arrow.Kind
+import arrow.KindDeprecation
 import arrow.core.Const
 import arrow.core.Either
 import arrow.core.ListK

--- a/arrow-optics/src/main/kotlin/arrow/optics/hks.kt
+++ b/arrow-optics/src/main/kotlin/arrow/optics/hks.kt
@@ -1,5 +1,0 @@
-package arrow.optics
-
-// TODO: Remove this message once it is added into arrow core
-const val KindDeprecation =
-  """Higher Kinded types and their related type classes will no longer be supported after Arrow 0.13.0. Most relevant APIs are now concrete over the data types available as members or top level extension functions"""


### PR DESCRIPTION
We added a const value for the message used for deprecating the Higher Kinded Types. But Arrow Core already provides that message, so we are removing it from this repo.